### PR TITLE
Add Graphite 2.0 beta announcement banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,17 @@
                 </div>
         </div>
 		</header>
+		<!-- Beta Announcement Banner -->
+		<div class="beta-announcement">
+			<div class="container">
+				<div class="row justify-content-center">
+					<div class="col-auto">
+						<span class="beta-badge">BETA</span>
+						<span class="beta-text"><a href="https://graphite.netreplica.com" target="_blank" class="beta-link">Graphite 2.0</a> preview now available</span>
+					</div>
+				</div>
+			</div>
+		</div>
 		<main>
             <!-- Product: nrx -->
             <section class="product-section py-5">

--- a/style.css
+++ b/style.css
@@ -1,5 +1,59 @@
 /* Custom styles for Netreplica - works with Bootstrap */
 
+/* Beta Announcement Banner */
+.beta-announcement {
+	background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+	padding: 12px 20px;
+	text-align: center;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.beta-badge {
+	background-color: rgba(255, 255, 255, 0.3);
+	color: #ffffff;
+	font-weight: 700;
+	font-size: 0.75rem;
+	padding: 4px 8px;
+	border-radius: 4px;
+	margin-right: 12px;
+	letter-spacing: 1px;
+}
+
+.beta-text {
+	color: #ffffff;
+	font-size: 1rem;
+	font-weight: 500;
+}
+
+.beta-link {
+	color: #ffffff;
+	font-weight: 700;
+	text-decoration: underline;
+	transition: opacity 0.2s ease;
+}
+
+.beta-link:hover {
+	color: #ffffff;
+	opacity: 0.8;
+}
+
+/* Responsive adjustments for beta banner */
+@media (max-width: 768px) {
+	.beta-announcement {
+		padding: 10px 15px;
+	}
+
+	.beta-text {
+		font-size: 0.9rem;
+	}
+
+	.beta-badge {
+		display: block;
+		margin-bottom: 8px;
+		margin-right: 0;
+	}
+}
+
 /* Hero logo styling */
 .hero-logo {
 	max-width: 400px;


### PR DESCRIPTION
## Summary
- Added a prominent beta announcement banner for Graphite 2.0
- Positioned below the hero section for visibility
- Purple gradient background with "BETA" badge
- Clean, clickable link on "Graphite 2.0" text to graphite.netreplica.com
- Fully responsive design with mobile-optimized layout

## Design Details
- Eye-catching gradient: purple to violet
- Semi-transparent BETA badge for professional look
- Bold, underlined link with smooth hover effect
- Opens in new tab for better UX
- On mobile, BETA badge stacks above text

## Test plan
- [ ] Verify banner appears below hero section
- [ ] Test link opens https://graphite.netreplica.com in new tab
- [ ] Check responsive layout on mobile, tablet, and desktop
- [ ] Verify gradient background displays correctly
- [ ] Test hover effect on "Graphite 2.0" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)